### PR TITLE
Added integration test for batchtransactions endpoint

### DIFF
--- a/src/main/java/org/mifos/integrationtest/config/BulkProcessorConfig.java
+++ b/src/main/java/org/mifos/integrationtest/config/BulkProcessorConfig.java
@@ -1,0 +1,24 @@
+package org.mifos.integrationtest.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+
+@Component
+public class BulkProcessorConfig {
+
+    @Value("${bulk-processor.contactpoint}")
+    public String bulkProcessorContactPoint;
+
+    @Value("${bulk-processor.endpoints.bulk-transactions}")
+    public String bulkTransactionEndpoint;
+
+    public String bulkTransactionUrl;
+
+    @PostConstruct
+    private void setup() {
+        bulkTransactionUrl = bulkProcessorContactPoint + bulkTransactionEndpoint;
+    }
+
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,3 +7,8 @@ operations-app:
     batch-summary: "/api/v1/batch"
     batch-details: "api/v1/batch/detail"
     batch-transaction: "/api/v1/batch/transactions"
+
+bulk-processor:
+  contactpoint: "https://bulk-connector.sandbox.fynarfin.io"
+  endpoints:
+    bulk-transactions: "/batchtransactions"

--- a/src/test/java/org/mifos/integrationtest/common/Utils.java
+++ b/src/test/java/org/mifos/integrationtest/common/Utils.java
@@ -35,4 +35,9 @@ public class Utils {
         return requestSpec;
     }
 
+    public static String getAbsoluteFilePathToResource(String fileName) {
+        return "src/test/java/resources/" +
+                fileName;
+    }
+
 }

--- a/src/test/java/org/mifos/integrationtest/cucumber/BaseStepDef.java
+++ b/src/test/java/org/mifos/integrationtest/cucumber/BaseStepDef.java
@@ -1,6 +1,7 @@
 package org.mifos.integrationtest.cucumber;
 
 import io.cucumber.core.internal.com.fasterxml.jackson.databind.ObjectMapper;
+import org.mifos.integrationtest.config.BulkProcessorConfig;
 import org.mifos.integrationtest.config.OperationsAppConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,11 +16,15 @@ public class BaseStepDef {
     @Autowired
     OperationsAppConfig operationsAppConfig;
 
+    @Autowired
+    BulkProcessorConfig bulkProcessorConfig;
+
     Logger logger = LoggerFactory.getLogger(this.getClass());
 
     protected static String batchId;
     protected static String tenant;
     protected static String response;
     protected static String accessToken;
+    protected static String filename;
 
 }

--- a/src/test/java/org/mifos/integrationtest/cucumber/BatchApiStepDef.java
+++ b/src/test/java/org/mifos/integrationtest/cucumber/BatchApiStepDef.java
@@ -9,6 +9,9 @@ import io.restassured.builder.ResponseSpecBuilder;
 import io.restassured.specification.RequestSpecification;
 import org.mifos.integrationtest.common.Utils;
 
+import java.io.File;
+import java.util.UUID;
+
 import static com.google.common.truth.Truth.assertThat;
 
 public class BatchApiStepDef extends BaseStepDef {
@@ -17,6 +20,12 @@ public class BatchApiStepDef extends BaseStepDef {
     public void setBatchId(String batchId) {
         BaseStepDef.batchId = batchId;
         assertThat(BaseStepDef.batchId).isNotEmpty();
+    }
+
+    @Given("I have the demo csv file {string}")
+    public void setFilename(String filename) {
+        BaseStepDef.filename = filename;
+        assertThat(BaseStepDef.filename).isNotEmpty();
     }
 
     @And("I have tenant as {string}")
@@ -59,9 +68,35 @@ public class BatchApiStepDef extends BaseStepDef {
         logger.info("Batch Details Response: " + BaseStepDef.response);
     }
 
+    @When("I call the batch transactions endpoint with expected status of {int}")
+    public void callBatchTransactionsEndpoint(int expectedStatus) {
+        RequestSpecification requestSpec = Utils.getDefaultSpec(BaseStepDef.tenant);
+        requestSpec.header("filename", BaseStepDef.filename);
+        requestSpec.header("X-CorrelationID", UUID.randomUUID().toString());
+        requestSpec.queryParam("type", "CSV");
+
+        BaseStepDef.response = RestAssured.given(requestSpec)
+                .baseUri(bulkProcessorConfig.bulkProcessorContactPoint)
+                .contentType("multipart/form-data")
+                .multiPart("data", Utils.getAbsoluteFilePathToResource(BaseStepDef.filename))
+                .expect()
+                .spec(new ResponseSpecBuilder().expectStatusCode(expectedStatus).build())
+                .when()
+                .post(operationsAppConfig.batchDetailsEndpoint)
+                .andReturn().asString();
+
+        logger.info("Batch Details Response: " + BaseStepDef.response);
+    }
+
     @Then("I should get non empty response")
     public void nonEmptyResponseCheck() {
         assertThat(BaseStepDef.response).isNotNull();
+    }
+
+    public static void main(String[] args) {
+        String name = "ph-ee-bulk-demo-6.csv";
+        File file = new File(Utils.getAbsoluteFilePathToResource(name));
+        System.out.println(file.exists());
     }
 
 }

--- a/src/test/java/resources/batch.feature
+++ b/src/test/java/resources/batch.feature
@@ -16,3 +16,10 @@ Feature: Batch Details API test
     Then I should get a valid token
     When I call the batch details API with expected status of 200
     Then I should get non empty response
+
+
+  Scenario: Batch transactions API Test
+    Given I have the demo csv file "ph-ee-bulk-demo-6.csv"
+    And I have tenant as "gorilla"
+    When I call the batch transactions endpoint with expected status of 200
+    Then I should get non empty response

--- a/src/test/java/resources/ph-ee-bulk-demo-6.csv
+++ b/src/test/java/resources/ph-ee-bulk-demo-6.csv
@@ -1,0 +1,13 @@
+id,request_id,payment_mode,payer_identifier_type,payer_identifier,payee_identifier_type,payee_identifier,amount,currency,note
+0,f1e22fe3-9740-4fba-97b6-78f43bfa7f2f,slcb,accountNumber,003001003879112168,accountNumber,003001003873110196,850,USD,Test Payee Payment
+1,72aa3ea4-e6f6-4880-877f-39f6ac4d052e,slcb,accountNumber,003001003879112168,accountNumber,003001003874120160,222,USD,Test Payee Payment
+2,f1e22fe3-9740-4fba-97b6-78f43bfa7f2f,slcb,accountNumber,003001003879112168,accountNumber,003001003873110196,850,USD,Test Payee Payment
+3,72aa3ea4-e6f6-4880-877f-39f6ac4d052e,slcb,accountNumber,003001003879112168,accountNumber,003001003874120160,222,USD,Test Payee Payment
+4,f1e22fe3-9740-4fba-97b6-78f43bfa7f2f,slcb,accountNumber,003001003879112168,accountNumber,003001003873110196,850,USD,Test Payee Payment
+5,72aa3ea4-e6f6-4880-877f-39f6ac4d052e,slcb,accountNumber,003001003879112168,accountNumber,003001003874120160,222,USD,Test Payee Payment
+6,f1e22fe3-9740-4fba-97b6-78f43bfa7f2f,slcb,accountNumber,003001003879112168,accountNumber,003001003873110196,850,USD,Test Payee Payment
+7,72aa3ea4-e6f6-4880-877f-39f6ac4d052e,slcb,accountNumber,003001003879112168,accountNumber,003001003874120160,222,USD,Test Payee Payment
+8,f1e22fe3-9740-4fba-97b6-78f43bfa7f2f,slcb,accountNumber,003001003879112168,accountNumber,003001003873110196,850,USD,Test Payee Payment
+9,72aa3ea4-e6f6-4880-877f-39f6ac4d052e,slcb,accountNumber,003001003879112168,accountNumber,003001003874120160,222,USD,Test Payee Payment
+10,f1e22fe3-9740-4fba-97b6-78f43bfa7f2f,slcb,accountNumber,003001003879112168,accountNumber,003001003873110196,850,USD,Test Payee Payment
+11,72aa3ea4-e6f6-4880-877f-39f6ac4d052e,slcb,accountNumber,003001003879112168,accountNumber,003001003874120160,222,USD,Test Payee Payment


### PR DESCRIPTION
Updates in this PR
1. New test case for bulk transaction API or `/batchtransactions` endpoint.
2. Added a new config named `BulkProcessorConfig.java`, for the configurations like contactpoint and endpoints related to bulk-processor.
3. Added demo CSV file named `ph-ee-bulk-demo-6.csv`, to be used for this endpoint.