### PR TITLE
COMPLETES - 237: Added mock server config and basic test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
+    testImplementation "com.github.tomakehurst:wiremock-jre8:2.35.0"
     implementation 'org.mifos:ph-ee-connector-common:1.2.2-SNAPSHOT'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     implementation 'org.mifos:ph-ee-connector-common:1.2.2-SNAPSHOT'

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -58,3 +58,6 @@ savings:
     approve-endpoint: /fineract-provider/api/v1/savingsaccounts/{{savingsAccId}}
     activate-endpoint: /fineract-provider/api/v1/savingsaccounts/{{savingsAccId}}
     deposit-endpoint: /fineract-provider/api/v1/savingsaccounts/{{savingsAccId}}/transactions
+
+mock-server:
+  port: 53013

--- a/src/test/java/org/mifos/integrationtest/config/MockServer.java
+++ b/src/test/java/org/mifos/integrationtest/config/MockServer.java
@@ -1,0 +1,8 @@
+package org.mifos.integrationtest.config;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+
+public interface MockServer {
+
+    public WireMockServer getMockServer();
+}

--- a/src/test/java/org/mifos/integrationtest/config/MockServerConfig.java
+++ b/src/test/java/org/mifos/integrationtest/config/MockServerConfig.java
@@ -1,0 +1,27 @@
+package org.mifos.integrationtest.config;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+
+@Configuration
+public class MockServerConfig implements MockServer {
+
+    private static WireMockServer singleInstance = null;
+
+    @Value("${mock-server.port}")
+    private int port;
+
+    public WireMockServer getMockServer() {
+        if (MockServerConfig.singleInstance == null) {
+            MockServerConfig.singleInstance = new WireMockServer(wireMockConfig().port(this.port));
+            System.out.println("PORT: " + port);
+        }
+
+        return MockServerConfig.singleInstance;
+    }
+
+
+}

--- a/src/test/java/org/mifos/integrationtest/cucumber/stepdef/AuthStepDef.java
+++ b/src/test/java/org/mifos/integrationtest/cucumber/stepdef/AuthStepDef.java
@@ -1,4 +1,4 @@
-package org.mifos.integrationtest.cucumber;
+package org.mifos.integrationtest.cucumber.stepdef;
 
 import com.google.gson.Gson;
 import io.cucumber.java.en.Then;

--- a/src/test/java/org/mifos/integrationtest/cucumber/stepdef/BaseStepDef.java
+++ b/src/test/java/org/mifos/integrationtest/cucumber/stepdef/BaseStepDef.java
@@ -1,8 +1,9 @@
-package org.mifos.integrationtest.cucumber;
+package org.mifos.integrationtest.cucumber.stepdef;
 
 import io.cucumber.core.internal.com.fasterxml.jackson.databind.ObjectMapper;
 import org.mifos.integrationtest.config.BulkProcessorConfig;
 import org.mifos.integrationtest.config.ChannelConnectorConfig;
+import org.mifos.integrationtest.config.MockServer;
 import org.mifos.integrationtest.config.OperationsAppConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,6 +24,9 @@ public class BaseStepDef {
 
     @Autowired
     ChannelConnectorConfig channelConnectorConfig;
+
+    @Autowired
+    MockServer mockServer;
 
     @Value("${operations-app.auth.enabled}")
     public Boolean authEnabled;

--- a/src/test/java/org/mifos/integrationtest/cucumber/stepdef/BatchApiStepDef.java
+++ b/src/test/java/org/mifos/integrationtest/cucumber/stepdef/BatchApiStepDef.java
@@ -1,4 +1,4 @@
-package org.mifos.integrationtest.cucumber;
+package org.mifos.integrationtest.cucumber.stepdef;
 
 import io.cucumber.core.internal.com.fasterxml.jackson.core.JsonProcessingException;
 import io.cucumber.java.en.And;

--- a/src/test/java/org/mifos/integrationtest/cucumber/stepdef/ChannelClientIdDef.java
+++ b/src/test/java/org/mifos/integrationtest/cucumber/stepdef/ChannelClientIdDef.java
@@ -1,4 +1,4 @@
-package org.mifos.integrationtest.cucumber;
+package org.mifos.integrationtest.cucumber.stepdef;
 
 import io.cucumber.java.en.And;
 

--- a/src/test/java/org/mifos/integrationtest/cucumber/stepdef/ContextStepDef.java
+++ b/src/test/java/org/mifos/integrationtest/cucumber/stepdef/ContextStepDef.java
@@ -1,0 +1,24 @@
+package org.mifos.integrationtest.cucumber.stepdef;
+
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import static com.google.common.truth.Truth.assertThat;
+
+public class ContextStepDef extends BaseStepDef {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Given("I can autowire the object mapper bean")
+    public void checkIfObjectMapperIsInjected() {
+        assertThat(objectMapper).isNotNull();
+    }
+
+    @Then("Application context should be not null")
+    public void checkIfApplicationContextIsStarted() {
+        assertThat(this.applicationContext).isNotNull();
+    }
+
+}

--- a/src/test/java/org/mifos/integrationtest/cucumber/stepdef/ErrorCodeStepDef.java
+++ b/src/test/java/org/mifos/integrationtest/cucumber/stepdef/ErrorCodeStepDef.java
@@ -1,4 +1,4 @@
-package org.mifos.integrationtest.cucumber;
+package org.mifos.integrationtest.cucumber.stepdef;
 
 import io.cucumber.core.internal.com.fasterxml.jackson.core.JsonProcessingException;
 import io.cucumber.core.internal.com.fasterxml.jackson.databind.JsonMappingException;

--- a/src/test/java/org/mifos/integrationtest/cucumber/stepdef/GSMATransferDef.java
+++ b/src/test/java/org/mifos/integrationtest/cucumber/stepdef/GSMATransferDef.java
@@ -1,4 +1,4 @@
-package org.mifos.integrationtest.cucumber;
+package org.mifos.integrationtest.cucumber.stepdef;
 
 import io.cucumber.core.internal.com.fasterxml.jackson.core.JsonProcessingException;
 import io.cucumber.core.internal.com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/test/java/org/mifos/integrationtest/cucumber/stepdef/GSMATransferStepDef.java
+++ b/src/test/java/org/mifos/integrationtest/cucumber/stepdef/GSMATransferStepDef.java
@@ -1,4 +1,4 @@
-package org.mifos.integrationtest.cucumber;
+package org.mifos.integrationtest.cucumber.stepdef;
 
 import io.cucumber.core.internal.com.fasterxml.jackson.core.JsonProcessingException;
 import io.cucumber.core.internal.com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/test/java/org/mifos/integrationtest/cucumber/stepdef/GetTxnApiDef.java
+++ b/src/test/java/org/mifos/integrationtest/cucumber/stepdef/GetTxnApiDef.java
@@ -1,4 +1,4 @@
-package org.mifos.integrationtest.cucumber;
+package org.mifos.integrationtest.cucumber.stepdef;
 
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.When;

--- a/src/test/java/org/mifos/integrationtest/cucumber/stepdef/InboundStepDef.java
+++ b/src/test/java/org/mifos/integrationtest/cucumber/stepdef/InboundStepDef.java
@@ -1,4 +1,4 @@
-package org.mifos.integrationtest.cucumber;
+package org.mifos.integrationtest.cucumber.stepdef;
 
 import io.cucumber.core.internal.com.fasterxml.jackson.core.JsonProcessingException;
 import io.cucumber.java.en.And;

--- a/src/test/java/org/mifos/integrationtest/cucumber/stepdef/MockServerStepDef.java
+++ b/src/test/java/org/mifos/integrationtest/cucumber/stepdef/MockServerStepDef.java
@@ -1,0 +1,30 @@
+package org.mifos.integrationtest.cucumber.stepdef;
+
+
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import org.springframework.beans.factory.annotation.Value;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static com.google.common.truth.Truth.assertThat;
+
+public class MockServerStepDef extends BaseStepDef {
+
+    @Value("${mock-server.port}")
+    private int mockServerPortFromConfig;
+
+    @Given("I can inject MockServer")
+    public void checkIfMockServerIsInjected() {
+        assertThat(mockServer).isNotNull();
+        mockServer.getMockServer().start();
+        configureFor("localhost", mockServer.getMockServer().port());
+    }
+
+    @Then("I should be able to get instance of mock server")
+    public void getInstanceOfMockServer() throws InterruptedException {
+        assertThat(mockServer.getMockServer()).isNotNull();
+        assertThat(mockServer.getMockServer().port()).isEqualTo(mockServerPortFromConfig);
+    }
+
+}

--- a/src/test/java/resources/context.feature
+++ b/src/test/java/resources/context.feature
@@ -1,0 +1,5 @@
+Feature: Testing if context is loaded or not
+
+  Scenario: Checking if application context is starter or not
+    Given I can autowire the object mapper bean
+    Then Application context should be not null

--- a/src/test/java/resources/mockserver.feature
+++ b/src/test/java/resources/mockserver.feature
@@ -1,0 +1,7 @@
+Feature: Testing the startup and working of mockserver
+
+  Scenario: Mockserver config test
+    Given I can inject MockServer
+    Then I should be able to get instance of mock server
+
+


### PR DESCRIPTION
Addresses [PHEE-237](https://fynarfin.atlassian.net/jira/software/c/projects/PHEE/issues/PHEE-237)

Changes in this PR
1. Move all the step def into dedicated `stepdef` package.
2. New `mock-server` dependency and its basic setup.
3. Added test case to make sure previous application context is not broken.
4. Added test case to make sure mockServer injection and configuration works as expected.

[PHEE-237]: https://fynarfin.atlassian.net/browse/PHEE-237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ